### PR TITLE
[BUGFIX] Hide tags if not set or empty string

### DIFF
--- a/Resources/Private/TypoScript/Prototypes/News.ts2
+++ b/Resources/Private/TypoScript/Prototypes/News.ts2
@@ -17,7 +17,7 @@ prototype(Lelesys.News:News) {
 	teaserText = ${q(node).children('main').children('[instanceof TYPO3.Neos.NodeTypes:Text]').property('text')}
 
 	# split tags with comma seperated
-	tags = ${q(node).property('tags') != null ? String.split(q(node).property('tags'), ',') : null}
+	tags = ${q(node).property('tags') != null && q(node).property('tags') != '' ? String.split(q(node).property('tags'), ',') : null}
 
 	# the node where the list view is presented
 	# this can be overridden to change the different news list view


### PR DESCRIPTION
It seems that tags are not `null` but an empty string if the field in the inspector is empty, so we should test for that too.