### PR TITLE
FEATURE: Elasticsearch support for collecting news

### DIFF
--- a/Configuration/NodeTypes.yaml
+++ b/Configuration/NodeTypes.yaml
@@ -199,7 +199,7 @@
                 label: ''
               'dateTime':
                 label: 'Date'
-              'autherName':
+              'authorName':
                 label: 'Author name'
               'title':
                 label: 'Title'

--- a/Configuration/NodeTypes.yaml
+++ b/Configuration/NodeTypes.yaml
@@ -93,6 +93,11 @@
       validation:
         'TYPO3.Neos/Validation/NotEmptyValidator': []
         'TYPO3.Neos/Validation/DateTimeValidator': []
+      search:
+        elasticSearchMapping:
+          type: 'date'
+          format: 'date_time_no_millis'
+        indexing: '${(value ? Date.format(value, "Y-m-d\TH:i:sP") : null)}'
     relatedNews:
       type: references
       ui:
@@ -112,6 +117,12 @@
       validation:
         regularExpression:
           regularExpression: '/[a-zA-Z0-9\,]/'
+      search:
+        elasticSearchMapping:
+          type: string
+          index: not_analyzed
+          include_in_all: false
+        indexing: ${String.split(value, ',')}
     categories:
       type: references
       ui:

--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ prototype(Lelesys.News:Latest) {
 }
 ```
 
+The list view fetches a maximum of 1000 items (before pagination is applied!), this can be adjusted with:
+
+```
+newsCollection = Lelesys.News:ElasticsearchNewsCollector {
+    value.@process.limit = ${value.limit(42)}
+}
+```
+
 To enable logging of the queries sent to Elasticsearch (`Data/Logs/ElasticSearch.log`), you can do:
 
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,49 @@
-Lelesys.News
-============
+# Lelesys.News
 
 Please find documentation at following link:
 
 http://www.lelesys.com/en/technology/about-typo3-neos/neos-packages/news-package-extension-for-typo3-neos.html
+
+Even though it is for the first version, it still is valid.
+
+## Using Elasticsearch
+
+To speed up handling of news filtering and sorting, using Elasticsearch is recommended.
+
+If you have the installed `flowpack/elasticsearch-contentrepositoryadaptor` (and its dependencies), news
+will be indexed correctly. If you already have created news before installing the Elasticsearch adaptor,
+run `./flow nodeindex:build` to create the index.
+
+The configure the plugin to use Elasticsearch to fetch the news add this to your TypoScript:
+
+```
+prototype(Lelesys.News:List) {
+    newsCollection = Lelesys.News:ElasticsearchNewsCollector
+}
+
+prototype(Lelesys.News:Latest) {
+    newsCollection.value.@process.slice = ${value.limit(String.toInteger(configuration.numberOfItems))}
+    newsCollection.value.@process.toArray = ${value.toArray()}
+    newsCollection.value.@process.toArray.@position = 'after execute'
+}
+```
+
+To enable logging of the queries sent to Elasticsearch (`Data/Logs/ElasticSearch.log`), you can do:
+
+```
+newsCollection = Lelesys.News:ElasticsearchNewsCollector {
+    value.@process.log = ${value.log()}
+    value.@process.log.@position = 'before execute'
+}
+```
+
+Similarly you can adjust the query by adding further filters, the `value` in the collector is an instance
+of the `ElasticSearchQueryBuilder`:
+
+```
+newsCollection = Lelesys.News:ElasticsearchNewsCollector {
+    # exclude "hidden in menu" entries from the List`s news collection
+    value.@process.filterHiddenInIndex= ${value.queryFilter('term', {'_hiddenInIndex': true}, 'must_not')}
+    value.@process.filterHiddenInIndex.@position = 'before execute'
+}
+```

--- a/Resources/Private/TypoScript/Objects/ElasticsearchNewsCollector.ts2
+++ b/Resources/Private/TypoScript/Objects/ElasticsearchNewsCollector.ts2
@@ -9,6 +9,7 @@ prototype(Lelesys.News:ElasticsearchNewsCollector) < prototype(TYPO3.TypoScript:
     value.@process.filterByCategoryAndTag = ${value.queryFilterMultiple(this.categoryAndTagFilter)}
     value.@process.filterByDate = ${request.arguments.year ? value.queryFilter('range', this.dateFilter) : value}
     value.@process.sort = ${configuration.sortOrder == 'ASC' ? value.sortAsc(configuration.sortProperty) : value.sortDesc(configuration.sortProperty)}
+    value.@process.limit = ${value.limit(1000)}
 
     value.@process.execute = ${value.execute()}
 }

--- a/Resources/Private/TypoScript/Objects/ElasticsearchNewsCollector.ts2
+++ b/Resources/Private/TypoScript/Objects/ElasticsearchNewsCollector.ts2
@@ -1,0 +1,54 @@
+#
+# Collects news items using a Query against the Elasticsearch index for the website
+#
+prototype(Lelesys.News:ElasticsearchNewsCollector) < prototype(TYPO3.TypoScript:Value) {
+    categoryAndTagFilter = Lelesys.News:ElasticsearchCategoryAndTagFilter
+    dateFilter = Lelesys.News:ElasticsearchDateFilter
+
+    value = ${Search.query(newsFolderNode).nodeType('Lelesys.News:News')}
+    value.@process.filterByCategoryAndTag = ${value.queryFilterMultiple(this.categoryAndTagFilter)}
+    value.@process.filterByDate = ${request.arguments.year ? value.queryFilter('range', this.dateFilter) : value}
+    value.@process.sort = ${configuration.sortOrder == 'ASC' ? value.sortAsc(configuration.sortProperty) : value.sortDesc(configuration.sortProperty)}
+
+    value.@process.execute = ${value.execute()}
+}
+
+#
+# returns a raw array to use for category / tag filtering
+#
+prototype(Lelesys.News:ElasticsearchCategoryAndTagFilter) < prototype(TYPO3.TypoScript:Value) {
+    value = TYPO3.TypoScript:RawArray {
+        catgeories = ${q(node).is('[instanceof Lelesys.News:List]') ? (q(node).property('filterByCategories') ? q(node).property('filterByCategories') : null) : null}
+        tags = ${request.arguments.tag}
+    }
+}
+
+#
+# returns a raw array to use for date filtering
+#
+prototype(Lelesys.News:ElasticsearchDateFilter) < prototype(TYPO3.TypoScript:Value) {
+    filterByDateStart = TYPO3.TypoScript:Case {
+        yearAndMonth {
+            condition = ${request.arguments.year && request.arguments.month}
+            renderer = ${Date.parse(request.arguments.month + '/' + request.arguments.year, 'm/Y')}
+        }
+        year {
+            condition = ${request.arguments.year}
+            renderer = ${Date.parse('01/' + request.arguments.year, 'm/Y')}
+        }
+        default {
+            condition = true
+            renderer = ${Date.now()}
+        }
+    }
+    @context.filterByDateStart = ${this.filterByDateStart}
+    @context.filterByDateEnd = ${request.arguments.month ? Date.add(this.filterByDateStart, 'P1M') : Date.add(this.filterByDateStart, 'P1Y')}
+
+    value = TYPO3.TypoScript:RawArray {
+        dateTime = TYPO3.TypoScript:RawArray {
+            gte = ${Date.format(filterByDateStart, 'm/Y')}
+            lt = ${Date.format(filterByDateEnd, 'm/Y')}
+            format = 'MM/yyyy'
+        }
+    }
+}

--- a/Resources/Private/TypoScript/Objects/NewsCollector.ts2
+++ b/Resources/Private/TypoScript/Objects/NewsCollector.ts2
@@ -1,0 +1,25 @@
+prototype(Lelesys.News:NewsCollector) < prototype(TYPO3.TypoScript:Value) {
+    value = ${q(newsFolderNode).children('[instanceof Lelesys.News:News]').get()}
+
+    # Filter and sorting
+    @context.filterByCategories = ${q(node).is('[instanceof Lelesys.News:List]') ? q(node).property_array('filterByCategories') != null ? Array.join(q(node).property_array('filterByCategories')) : '' : ''}
+    @context.filterByTag = ${request.arguments.tag}
+    @context.filterByYear = ${request.arguments.year}
+    @context.filterByMonth = ${request.arguments.month}
+
+    # 1. filter the news collection by one or many categories if applicable
+    # this internally uses the extended filter() operation
+    value.@process.filterByCategories = ${filterByCategories != null && filterByCategories != '' ? q(value).filter('[categories *= \'' + filterByCategories + '\']').get() : value}
+
+    # 2. filter the news collection by given year if applicable
+    value.@process.filterByYear = ${filterByYear != null && filterByMonth == null ? q(value).filter('[dateTime = \'' + filterByYear + '\']', 'Y').get() : value}
+
+    # 3. filter the news collection by given year and month if applicable
+    value.@process.filterByYearAndMonth = ${filterByYear != null && filterByMonth != null ? q(value).filter('[dateTime = \'' + filterByYear + '/' + filterByMonth + '\']', 'Y/m').get() : value}
+
+    # 4. filter the news collection by a tag if applicable
+    value.@process.filterByTag = ${filterByTag != null ? q(value).filter('[tags *= ' + filterByTag + ']').get() : value}
+
+    # sort nodes
+    value.@process.sort = ${q(value).count() > 0 ? q(value).sort(configuration.sortProperty, configuration.sortOrder).get() : value}
+}

--- a/Resources/Private/TypoScript/Prototypes/ArchiveMenu.ts2
+++ b/Resources/Private/TypoScript/Prototypes/ArchiveMenu.ts2
@@ -10,6 +10,6 @@ prototype(Lelesys.News:ArchiveMenu) < prototype(TYPO3.Neos.NodeTypes:Menu) {
 
 	# the node where the list view is presented, defaults to the startingPoint
 	# this can be overridden to change the different news list view
-	@override.newsListNode = ${this.startingPoint}
+	@context.newsListNode = ${this.startingPoint}
 	newsListNode = ${newsListNode}
 }

--- a/Resources/Private/TypoScript/Prototypes/Category.ts2
+++ b/Resources/Private/TypoScript/Prototypes/Category.ts2
@@ -10,5 +10,5 @@ prototype(Lelesys.News:Category) {
 
 	# load list of news filtered by this category
 	newsList = Lelesys.News:List
-	newsList.@override.filterByCategories = ${node.identifier}
+	newsList.@context.filterByCategories = ${node.identifier}
 }

--- a/Resources/Private/TypoScript/Prototypes/Latest.ts2
+++ b/Resources/Private/TypoScript/Prototypes/Latest.ts2
@@ -1,8 +1,8 @@
 # News latest (almost same as list)
 prototype(Lelesys.News:Latest) < prototype(Lelesys.News:List) {
 	# load merged configuration
-	@override.configuration = ${Configuration.setting('Lelesys.News.view.latest')}
-	@overrode.configuration.@process.mergeConfiguration = ${NewsConfiguration.mergeWithNodeProperties(value, node)}
+	@context.configuration = ${Configuration.setting('Lelesys.News.view.latest')}
+	@context.configuration.@process.mergeConfiguration = ${NewsConfiguration.mergeWithNodeProperties(value, node)}
 	configuration = ${configuration}
 
 	# this renders a single item inside the latest view

--- a/Resources/Private/TypoScript/Prototypes/Latest.ts2
+++ b/Resources/Private/TypoScript/Prototypes/Latest.ts2
@@ -12,5 +12,6 @@ prototype(Lelesys.News:Latest) < prototype(Lelesys.News:List) {
 	}
 
 	# show only few nodes
-	newsCollection.@process.slice = ${q(value).count() > 0 ? q(value).slice(0, String.toInteger(configuration.numberOfItems)).get() : value}
+	newsCollection.value.@process.slice = ${q(value).count() > 0 ? q(value).slice(0, String.toInteger(configuration.numberOfItems)).get() : value}
+	newsCollection.value.@process.slice.@position = 'after sort'
 }

--- a/Resources/Private/TypoScript/Prototypes/List.ts2
+++ b/Resources/Private/TypoScript/Prototypes/List.ts2
@@ -19,6 +19,7 @@ prototype(Lelesys.News:List) {
 	@context.configuration = ${this.configuration}
 
 	newsCollection = Lelesys.News:NewsCollector
+	newsCollection.@if.newsFolderFound = ${newsFolderNode != null}
 
 	# this renders a single item inside the list
 	newsItem = Lelesys.News:News

--- a/Resources/Private/TypoScript/Prototypes/List.ts2
+++ b/Resources/Private/TypoScript/Prototypes/List.ts2
@@ -6,7 +6,7 @@ prototype(Lelesys.News:List) {
 
 	# newsFolder is read from current node's newsFolder property if exists
 	# otherwise the closest Folder node is selected
-	@override.newsFolderNode = ${q(node).property('newsFolder') != null ? q(node).property('newsFolder') : q(node).closest('[instanceof Lelesys.News:Folder]')}
+	@context.newsFolderNode = ${q(node).property('newsFolder') != null ? q(node).property('newsFolder') : q(node).closest('[instanceof Lelesys.News:Folder]').get(0)}
 
 	# configuration merged from Settings and from the node properties.
 	# this way configuration can be changed globally for all sites in Settings.yaml OR
@@ -14,34 +14,11 @@ prototype(Lelesys.News:List) {
 	# if you set a new value for the configuration in the node property then it is only available
 	# for particular view. in this case if you do any change in Settings or TypoScript level
 	# then it will still take the configuration value from the node properties.
-	@override.configuration = ${Configuration.setting('Lelesys.News.view.list')}
-	@override.configuration.@process.mergeConfiguration = ${NewsConfiguration.mergeWithNodeProperties(value, node)}
-	configuration = ${configuration}
+	configuration = ${Configuration.setting('Lelesys.News.view.list')}
+	configuration.@process.mergeConfiguration = ${NewsConfiguration.mergeWithNodeProperties(value, node)}
+	@context.configuration = ${this.configuration}
 
-	# TODO - remove the condition if Content
-	newsCollection = ${q(node).is('[instanceof TYPO3.Neos:Content]') ? q(newsFolderNode).children('[instanceof Lelesys.News:News]').get() : newsFolderNode.children('[instanceof Lelesys.News:News]').get()}
-
-	# Filter and sorting
-	@override.filterByCategories = ${q(node).is('[instanceof Lelesys.News:List]') ? q(node).property_array('filterByCategories') != null ? Array.join(q(node).property_array('filterByCategories')) : '' : ''}
-	@override.filterByTag = ${request.arguments.tag}
-	@override.filterByYear = ${request.arguments.year}
-	@override.filterByMonth = ${request.arguments.month}
-
-	# 1. filter the news collection by one or many categories if applicable
-	# this internally uses the extended filter() operation
-	newsCollection.@process.filterByCategories = ${filterByCategories != null && filterByCategories != '' ? q(value).filter('[categories *= \'' + filterByCategories + '\']').get() : value}
-
-	# 2. filter the news collection by given year if applicable
-	newsCollection.@process.filterByYear = ${filterByYear != null && filterByMonth == null ? q(value).filter('[dateTime = \'' + filterByYear + '\']', 'Y').get() : value}
-
-	# 3. filter the news collection by given year and month if applicable
-	newsCollection.@process.filterByYearAndMonth = ${filterByYear != null && filterByMonth != null ? q(value).filter('[dateTime = \'' + filterByYear + '/' + filterByMonth + '\']', 'Y/m').get() : value}
-
-	# 4. filter the news collection by a tag if applicable
-	newsCollection.@process.filterByTag = ${filterByTag != null ? q(value).filter('[tags *= ' + filterByTag + ']').get() : value}
-
-	# sort nodes
-    newsCollection.@process.sort = ${q(value).count() > 0 ? q(value).sort(configuration.sortProperty, configuration.sortOrder).get() : value}
+	newsCollection = Lelesys.News:NewsCollector
 
 	# this renders a single item inside the list
 	newsItem = Lelesys.News:News

--- a/Resources/Private/TypoScript/Prototypes/News.ts2
+++ b/Resources/Private/TypoScript/Prototypes/News.ts2
@@ -2,8 +2,8 @@
 # inside other views like List, Latest by overriding the template path or
 # additional TS properties
 prototype(Lelesys.News:News) {
-	@override.configuration = ${inputConfiguration ? inputConfiguration : Configuration.setting('Lelesys.News.view.single')}
-	@override.configuration.@process.mergeConfiguration = ${inputConfiguration ? value : NewsConfiguration.mergeWithNodeProperties(value, node)}
+	@context.configuration = ${inputConfiguration ? inputConfiguration : Configuration.setting('Lelesys.News.view.single')}
+	@context.configuration.@process.mergeConfiguration = ${inputConfiguration ? value : NewsConfiguration.mergeWithNodeProperties(value, node)}
 	configuration = ${configuration}
 
 	# first image found in the news content becomes the thumbnail image to be shown in the
@@ -21,6 +21,6 @@ prototype(Lelesys.News:News) {
 
 	# the node where the list view is presented
 	# this can be overridden to change the different news list view
-	@override.newsListNode = ${q(node).closest('[instanceof Lelesys.News:Folder]').get(0)}
+	@context.newsListNode = ${q(node).closest('[instanceof Lelesys.News:Folder]').get(0)}
 	newsListNode = ${newsListNode}
 }

--- a/Resources/Private/TypoScript/Root.ts2
+++ b/Resources/Private/TypoScript/Root.ts2
@@ -1,15 +1,8 @@
 # Prototypes
-include: Prototypes/ArchiveMenu.ts2
-include: Prototypes/CategoryMenu.ts2
-include: Prototypes/News.ts2
-include: Prototypes/List.ts2
-include: Prototypes/Category.ts2
-include: Prototypes/Latest.ts2
-include: Prototypes/MetaTags.ts2
-include: Prototypes/ResponseManipulator.ts2
+include: Prototypes/*.ts2
 
 # Objects
-include: Objects/Rss.ts2
+include: Objects/*.ts2
 
 # Defaults for switching etc.
 include: DefaultTypoScript.ts2


### PR DESCRIPTION
This provides an Elasticsearch-based news collector that can be used as a
drop-in replacement for the original collector based on custom sorting and
filtering with Eel helpers.

Documentation on this is added to the README.md file.