### PR TITLE
TASK: Allow to disable thumbnails for news lists

### DIFF
--- a/Configuration/NodeTypes.yaml
+++ b/Configuration/NodeTypes.yaml
@@ -1,6 +1,19 @@
+'Lelesys.News:ThumbnailSwitchMixin':
+  abstract: TRUE
+  properties:
+    disableThumbnails:
+      type: boolean
+      defaultValue: false
+      ui:
+        label: 'Disable thumbnails'
+        reloadIfChanged: TRUE
+        inspector:
+          group: 'newsConfiguration'
+
 'Lelesys.News:Folder':
   superTypes:
     'TYPO3.Neos:Document': TRUE
+    'Lelesys.News:ThumbnailSwitchMixin': TRUE
   ui:
     label: 'News folder'
     icon: 'icon-folder-open'
@@ -23,6 +36,10 @@
       type: string
       ui:
         label: 'Feed description'
+        inspector:
+          group: 'news'
+    disableThumbnails:
+      ui:
         inspector:
           group: 'news'
 
@@ -269,6 +286,7 @@
 'Lelesys.News:List':
   superTypes:
     'TYPO3.Neos:Content': TRUE
+    'Lelesys.News:ThumbnailSwitchMixin': TRUE
     'Lelesys.News:Paginated': TRUE
     'Lelesys.News:Common': TRUE
   ui:
@@ -280,6 +298,7 @@
 'Lelesys.News:Latest':
   superTypes:
     'TYPO3.Neos:Content': TRUE
+    'Lelesys.News:ThumbnailSwitchMixin': TRUE
     'Lelesys.News:Common': TRUE
   ui:
     label: 'News latest'

--- a/Resources/Private/TypoScript/Prototypes/Latest.ts2
+++ b/Resources/Private/TypoScript/Prototypes/Latest.ts2
@@ -6,10 +6,7 @@ prototype(Lelesys.News:Latest) < prototype(Lelesys.News:List) {
 	configuration = ${configuration}
 
 	# this renders a single item inside the latest view
-	newsItem = Lelesys.News:News
-	newsItem {
-		templatePath = 'resource://Lelesys.News/Private/Templates/TypoScriptObjects/LatestItem.html'
-	}
+	newsItem.templatePath = 'resource://Lelesys.News/Private/Templates/TypoScriptObjects/LatestItem.html'
 
 	# show only few nodes
 	newsCollection.@process.slice = ${q(value).count() > 0 ? q(value).slice(0, String.toInteger(configuration.numberOfItems)).get() : value}

--- a/Resources/Private/TypoScript/Prototypes/List.ts2
+++ b/Resources/Private/TypoScript/Prototypes/List.ts2
@@ -44,9 +44,19 @@ prototype(Lelesys.News:List) {
     newsCollection.@process.sort = ${q(value).count() > 0 ? q(value).sort(configuration.sortProperty, configuration.sortOrder).get() : value}
 
 	# this renders a single item inside the list
-	newsItem = Lelesys.News:News
-	newsItem {
+	@context.disableThumbnails = ${q(node).property('disableThumbnails')}
+	newsItem = Lelesys.News:News {
 		templatePath = 'resource://Lelesys.News/Private/Templates/TypoScriptObjects/ListItem.html'
+		thumbnailImage = TYPO3.TypoScript:Case {
+			disabled {
+				condition = ${disableThumbnails}
+				renderer = ${null}
+			}
+			enabled {
+				condition = true
+				renderer = ${q(node).find('[instanceof TYPO3.Neos.NodeTypes:Image],[instanceof TYPO3.Neos.NodeTypes:TextWithImage]').first().get(0)}
+			}
+		}
 	}
 
 	# uncached the list view

--- a/Resources/Private/TypoScript/Prototypes/News.ts2
+++ b/Resources/Private/TypoScript/Prototypes/News.ts2
@@ -6,10 +6,6 @@ prototype(Lelesys.News:News) {
 	@override.configuration.@process.mergeConfiguration = ${inputConfiguration ? value : NewsConfiguration.mergeWithNodeProperties(value, node)}
 	configuration = ${configuration}
 
-	# first image found in the news content becomes the thumbnail image to be shown in the
-	# list and latest views
-	thumbnailImage = ${q(node).find('[instanceof TYPO3.Neos.NodeTypes:Image],[instanceof TYPO3.Neos.NodeTypes:TextWithImage]').first().get(0)}
-
 	main = TYPO3.Neos:ContentCollection
 	main.nodePath = 'main'
 


### PR DESCRIPTION
The fetching if a thumbnail from the news is an expensive operation. If you
do not need thumbnails in the list view (either with the news list or in a
news/category folder), you can now switch off thumbnails.

This speeds up rendering up to 10 times by avoiding the costly FlowQuery
used to look for (potential) thumbnails.