### PR TITLE
TASK: Relax version constraint on Neos to ^2.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
 		}
 	],
 	"require": {
-		"typo3/neos": "~2.3.0"
+		"typo3/neos": "^2.0.0"
 	},
 	"autoload": {
 		"psr-0": {


### PR DESCRIPTION
The package actually works for Neos 2.x in this state, so why not make
it universally accessible…